### PR TITLE
fix: adding apps subnet

### DIFF
--- a/infrastructure/app-web.tf
+++ b/infrastructure/app-web.tf
@@ -30,6 +30,7 @@ resource "azurerm_linux_web_app" "web_app" {
   client_certificate_enabled    = false
   https_only                    = true
   public_network_access_enabled = true
+  virtual_network_subnet_id     = azurerm_subnet.apps.id
 
   identity {
     type = "SystemAssigned"

--- a/infrastructure/environments/dev.tfvars
+++ b/infrastructure/environments/dev.tfvars
@@ -3,4 +3,5 @@ environment = "dev"
 vnet_config = {
   address_space             = "10.37.0.0/16"
   main_subnet_address_space = "10.37.1.0/24"
+  apps_subnet_address_space = "10.37.0.0/24"
 }

--- a/infrastructure/networking.tf
+++ b/infrastructure/networking.tf
@@ -7,6 +7,29 @@ resource "azurerm_virtual_network" "main" {
   tags = var.tags
 }
 
+resource "azurerm_subnet" "apps" {
+
+  #checkov:skip=CKV2_AZURE_31: "Ensure VNET subnet is configured with a Network Security Group (NSG)"
+
+  name                              = "${local.org}-snet-${local.service_name}-apps-${var.environment}"
+  resource_group_name               = azurerm_resource_group.primary.name
+  virtual_network_name              = azurerm_virtual_network.main.name
+  address_prefixes                  = [var.vnet_config.apps_subnet_address_space]
+  private_endpoint_network_policies = "Enabled"
+
+  # for app services
+  delegation {
+    name = "delegation"
+
+    service_delegation {
+      name = "Microsoft.Web/serverFarms"
+      actions = [
+        "Microsoft.Network/virtualNetworks/subnets/action"
+      ]
+    }
+  }
+}
+
 resource "azurerm_subnet" "main" {
   #checkov:skip=CKV2_AZURE_31: "Ensure VNET subnet is configured with a Network Security Group (NSG)"
   name                              = "${local.org}-snet-${local.resource_suffix}"

--- a/infrastructure/variables.tf
+++ b/infrastructure/variables.tf
@@ -24,5 +24,6 @@ variable "vnet_config" {
   type = object({
     address_space             = string
     main_subnet_address_space = string
+    apps_subnet_address_space = string
   })
 }


### PR DESCRIPTION
Adding apps subnet and integrating with all prototype app services 

This is to fix below issue

App service was not able to fetch secrets from key vault with private endpoint enabled. Below message would be displayed in Environment variables section
```Status
AccessToKeyVaultDenied
Error details
Key Vault reference was not able to be resolved because site was denied access to Key Vault reference's vault.```
